### PR TITLE
Release 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "centrex-tlf"
-version = "0.1.9"
+version = "0.2.0"
 description = ""
 authors = [
     {name = "ograsdijk", email = "o.grasdijk@gmail.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "centrex-tlf"
-version = "0.1.8.4"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
## Summary

- Bumps package version from 0.1.9 to 0.2.0 after merging the opposite-parity examples and Lindblad solver optimization work.
- Updates uv.lock's editable package version to match pyproject.toml.

## Validation

- uv build --wheel
- uv run --with twine twine check dist\\centrex_tlf-0.2.0-cp311-cp311-win_amd64.whl