### PR TITLE
0.2.3: warn on ambiguous state assignment, not impure labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,46 @@ Each of these produces plausible-looking but wrong output rather than an error.
   the field changes (in X J=2 the F=3, mF=±1 pair drops below F=2, mF=0 between 200 and
   250 V/cm), so `min(candidates, key=lambda i: H_int[i, i])` silently picks a different state at
   different fields.
+- **State labels stop being pure long before state *identification* breaks.** Stark mixing
+  drives the overlap of every X state with its bare label below 0.5 above roughly
+  400 V/cm (the four |mF|=1 levels in J=2 mix among themselves), and every B state below
+  0.5 by 100 V/cm when both Λ-doublet partners are retained — yet the assignment
+  `find_exact_states` returns is still exact in both cases, verified against adiabatic
+  continuation from zero field. So `find_exact_states_indices` no longer warns on low
+  purity by default (`overlap_threshold=None`, pass `0.5` to restore it). It warns instead
+  on a small or negative **margin** between the best and second-best overlap
+  (`margin_threshold=0.02`), the condition under which the label can actually land on the
+  wrong eigenvector.
+- **The margin warning is sufficient, not necessary.** It is calibrated to stay silent
+  wherever single-shot matching is genuinely correct (X to 10 kV/cm, B to 200 V/cm), which
+  forces the threshold low: at `0.12` an ordinary B analysis at 200 V/cm flags 52 of 192
+  states with nothing wrong. The price is incomplete coverage — at 30 kV/cm in X it catches
+  4 of 8 mis-assignments, at 1 kV/cm in B 10 of 44. Margins of mis-assigned states run as
+  high as +0.11 (X, 50 kV/cm) and +0.22 (B, 500 V/cm), so no threshold separates right from
+  wrong cleanly. **Silence is not a guarantee; use the field-based rule below.**
+- **Above ~10 kV/cm in X, or ~500 V/cm in B with both parities retained, match states
+  adiabatically — one-shot matching is wrong, not merely uncertain.** Converged X basis
+  (J=0–6, 196 levels): one-shot disagrees with tracking on 8 states at 20 and 30 kV/cm and
+  66 at 50 kV/cm. B (J=1–4, both parities, 192 levels): 12 states wrong at 500 V/cm, 44 at
+  1 kV/cm. In every case one-shot scores the *higher* total overlap (X 30 kV/cm: 91.83 vs
+  90.22 tracked), i.e. its objective prefers the physically wrong answer, so no
+  bare-overlap diagnostic can rescue it. Step the field up from ~0 and match each set of
+  eigenvectors to the previous set; the result is step-size independent (X: 50 vs 20 V/cm
+  steps to 50 kV/cm; B: 1.0 vs 0.2 V/cm steps to 1 kV/cm).
+  The OBE builders are exposed to this too. `generate_reduced_B_hamiltonian` diagonalizes
+  the *full* manifold — `J = 1 … J′+2`, `P=[-1, 1]`, `Ω=1`, every F₁/F/mF (120 states for
+  J′=1) — and matches against all of it; only `B_states_approx`, the handful of states the
+  transition names, gets a margin evaluated. Whether the builder warns therefore depends on
+  which manifold the transition targets: at 171.6 V/cm the J′=1 F₁=3/2 F=1 states sit at
+  margin +0.125, but J′=2 F₁=3/2 F=2 sits at +0.049 and does warn at a 0.12 threshold.
+  This is the concrete reason the default is 0.02 and not 0.12.
+- **At tens of kV/cm the J truncation must be raised — J≤3 does not have the physics.**
+  Going from `Jmax=3` to `Jmax=4` at 30 kV/cm shifts X state purities by 0.055 and
+  assignment margins by 0.092, i.e. more than the whole ambiguity threshold; it also
+  understates how badly one-shot matching breaks (24 wrong states at 50 kV/cm instead of
+  66). Converged by `Jmax=5`–`6` (Δmargin 5→6 is 0.0005, 6→7 is 0.0001). At 1 and 5 kV/cm
+  `Jmax=3` is already converged to 4 decimals, so this is specific to the tens-of-kV/cm
+  regime.
 - **`excited_main` must be reachable by the polarization in use.** With pure X̂ light and an mF=0
   ground state, only mF′=±1 is driven; choosing an mF′=0 `excited_main` makes `main_coupling` zero
   and the power→Rabi conversion divides by zero.
@@ -214,6 +254,14 @@ above `minimum_coupling=1e-3`. Measured convergence for an optical transition to
 `main_coupling` identical to six digits; raising `Jmax_B` from 3 to 6 leaves the B line offsets
 identical to four decimals. The defaults are converged at few-hundred V/cm fields — do not spend
 time re-deriving this, but do re-check if you move to kV/cm.
+
+Convergence of the *eigenvectors* (state purity and assignment margin) is the stricter test, since
+identification depends on them rather than on energies. For **B** the `J′+2` default is enough well
+past experimental fields: for a J′=2 target, going from `Jmax = J′+2` to `J′+5` changes purity and
+margin by 0.0000 at 171.6, 200, 500, 1000 and 5000 V/cm — only the `J′+1` basis is visibly off
+(0.008 in margin at 5 kV/cm). For **X** the default holds to a few kV/cm but not beyond: at
+30 kV/cm `Jmax=3` misses purity by 0.055 and margin by 0.092, and J=5–6 is needed (see the
+identification gotchas above).
 
 ## Beyond single-laser OBE
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ optimal assignment rather than a greedy per-eigenvector argmax.
 ### Added
 
 - `margin_threshold` (default 0.02) on `find_exact_states_indices` and
-  `find_exact_states`. It warns when the gap between the best and second-best overlap is
+  `find_exact_states`. It is the last parameter of both signatures, so existing
+  positional calls keep their meaning. It warns when the gap between the best and second-best overlap is
   small or negative, which is the condition under which a label can land on the wrong
   eigenvector. The warning names the competing eigenstate and its overlap. The default is
   chosen so the warning stays silent wherever single-shot matching is actually correct, in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## 0.2.3
+
+State identification now warns about assignments that are genuinely ambiguous instead of
+about state labels that are merely impure, and `reorder_evecs` orders eigenvectors with an
+optimal assignment rather than a greedy per-eigenvector argmax.
+
+### Compatibility notes
+
+- `find_exact_states_indices` and `find_exact_states` no longer warn on low overlap by
+  default: `overlap_threshold` now defaults to `None`. Pass `overlap_threshold=0.5` to
+  restore the previous behaviour. The old check measured label purity, which ordinary
+  Stark mixing drives below 0.5 (every X state above roughly 400 V/cm, every B state by
+  100 V/cm when both Lambda-doublet partners are retained) while the returned assignment
+  stays exact — verified against adiabatic continuation from zero field.
+- Returned indices are unchanged; only the warning behaviour and the eigenvector ordering
+  in strongly mixed cases differ.
+
+### Added
+
+- `margin_threshold` (default 0.02) on `find_exact_states_indices` and
+  `find_exact_states`. It warns when the gap between the best and second-best overlap is
+  small or negative, which is the condition under which a label can land on the wrong
+  eigenvector. The warning names the competing eigenstate and its overlap. The default is
+  chosen so the warning stays silent wherever single-shot matching is actually correct, in
+  X to 10 kV/cm and in B to 200 V/cm; a larger threshold produces false alarms on ordinary
+  builds (a J′=2 F₁=3/2 F=2 target at 171.6 V/cm flags at 0.12). It is a sufficient, not a
+  necessary, signal: above ~10 kV/cm in X or ~500 V/cm in B with both parities retained,
+  single-shot matching is unreliable regardless of the margin and states should be tracked
+  adiabatically.
+
+### Fixed
+
+- `reorder_evecs` matches eigenvectors to the reference with `linear_sum_assignment`
+  instead of `argsort(argmax(...))`. The greedy version had no uniqueness guarantee: once
+  two eigenvectors claimed the same reference column it returned a silently arbitrary
+  ordering. Output is identical wherever the greedy result was well defined; in X, J=0-3
+  at 20 kV/cm the total overlap with the reference improves from 26.20 to 44.56. The
+  change costs about 0.5 ms per OBE build. When `V_ref` has fewer columns than `V_in` the
+  unmatched eigenvectors are appended in their original order, so the output still holds
+  every eigenvector as it did before.
+
 ## 0.2.2
 
 Transition validity during OBE setup is now decided by the mixed-state dipole matrix

--- a/centrex_tlf/states/find_states.py
+++ b/centrex_tlf/states/find_states.py
@@ -317,8 +317,8 @@ def find_exact_states_indices(
     V: Optional[npt.NDArray[np.complex128]] = None,
     V_ref: Optional[npt.NDArray[np.complex128]] = None,
     overlap_threshold: Optional[float] = None,
-    margin_threshold: Optional[float] = 0.02,
     use_optimal_assignment: bool = True,
+    margin_threshold: Optional[float] = 0.02,
 ) -> npt.NDArray[np.int_]: ...
 
 
@@ -330,8 +330,8 @@ def find_exact_states_indices(
     V: Optional[npt.NDArray[np.complex128]] = None,
     V_ref: Optional[npt.NDArray[np.complex128]] = None,
     overlap_threshold: Optional[float] = None,
-    margin_threshold: Optional[float] = 0.02,
     use_optimal_assignment: bool = True,
+    margin_threshold: Optional[float] = 0.02,
 ) -> npt.NDArray[np.int_]: ...
 
 
@@ -342,8 +342,8 @@ def find_exact_states_indices(
     V: Optional[npt.NDArray[np.complex128]] = None,
     V_ref: Optional[npt.NDArray[np.complex128]] = None,
     overlap_threshold: Optional[float] = None,
-    margin_threshold: Optional[float] = 0.02,
     use_optimal_assignment: bool = True,
+    margin_threshold: Optional[float] = 0.02,
 ) -> npt.NDArray[np.int_]:
     """Find optimal eigenstate indices matching approximate states.
 
@@ -552,8 +552,8 @@ def find_exact_states(
     V: Optional[npt.NDArray[np.complex128]] = None,
     V_ref: Optional[npt.NDArray[np.complex128]] = None,
     overlap_threshold: Optional[float] = None,
-    margin_threshold: Optional[float] = 0.02,
     use_optimal_assignment: bool = True,
+    margin_threshold: Optional[float] = 0.02,
 ) -> List[CoupledState]: ...
 
 
@@ -566,8 +566,8 @@ def find_exact_states(
     V: Optional[npt.NDArray[np.complex128]] = None,
     V_ref: Optional[npt.NDArray[np.complex128]] = None,
     overlap_threshold: Optional[float] = None,
-    margin_threshold: Optional[float] = 0.02,
     use_optimal_assignment: bool = True,
+    margin_threshold: Optional[float] = 0.02,
 ) -> List[UncoupledState]: ...
 
 
@@ -579,8 +579,8 @@ def find_exact_states(
     V: Optional[npt.NDArray[np.complex128]] = None,
     V_ref: Optional[npt.NDArray[np.complex128]] = None,
     overlap_threshold: Optional[float] = None,
-    margin_threshold: Optional[float] = 0.02,
     use_optimal_assignment: bool = True,
+    margin_threshold: Optional[float] = 0.02,
 ):
     """Find exact eigenstates corresponding to approximate states.
 

--- a/centrex_tlf/states/find_states.py
+++ b/centrex_tlf/states/find_states.py
@@ -316,7 +316,8 @@ def find_exact_states_indices(
     H: Optional[npt.NDArray[np.complex128]] = None,
     V: Optional[npt.NDArray[np.complex128]] = None,
     V_ref: Optional[npt.NDArray[np.complex128]] = None,
-    overlap_threshold: float = 0.5,
+    overlap_threshold: Optional[float] = None,
+    margin_threshold: Optional[float] = 0.02,
     use_optimal_assignment: bool = True,
 ) -> npt.NDArray[np.int_]: ...
 
@@ -328,7 +329,8 @@ def find_exact_states_indices(
     H: Optional[npt.NDArray[np.complex128]] = None,
     V: Optional[npt.NDArray[np.complex128]] = None,
     V_ref: Optional[npt.NDArray[np.complex128]] = None,
-    overlap_threshold: float = 0.5,
+    overlap_threshold: Optional[float] = None,
+    margin_threshold: Optional[float] = 0.02,
     use_optimal_assignment: bool = True,
 ) -> npt.NDArray[np.int_]: ...
 
@@ -339,7 +341,8 @@ def find_exact_states_indices(
     H: Optional[npt.NDArray[np.complex128]] = None,
     V: Optional[npt.NDArray[np.complex128]] = None,
     V_ref: Optional[npt.NDArray[np.complex128]] = None,
-    overlap_threshold: float = 0.5,
+    overlap_threshold: Optional[float] = None,
+    margin_threshold: Optional[float] = 0.02,
     use_optimal_assignment: bool = True,
 ) -> npt.NDArray[np.int_]:
     """Find optimal eigenstate indices matching approximate states.
@@ -359,8 +362,24 @@ def find_exact_states_indices(
             shape (N, N). If None, computed from H. Defaults to None.
         V_ref (npt.NDArray[np.complex128] | None): Reference eigenvectors for
             consistent ordering/phase across multiple calculations. Defaults to None.
-        overlap_threshold (float): Minimum overlap probability to warn about poor
-            matching. Overlaps below this trigger UserWarning. Defaults to 0.5.
+        overlap_threshold (float | None): Minimum overlap probability to warn about
+            impure state labels. Overlaps below this trigger a UserWarning. This tests
+            label purity, not whether the assignment is correct: ordinary Stark mixing
+            drives the purity of every state below 0.5 while the assignment stays
+            exact, so it is off by default. Defaults to None (no purity check).
+        margin_threshold (float | None): Minimum gap between the best and second-best
+            overlap for an approximate state. A small or negative margin means the
+            assigned eigenstate is barely preferred over a competitor, so the labelling
+            can flip with a small change in field or numerical noise; this triggers a
+            UserWarning. The default is chosen so the warning is silent wherever a
+            single-shot match is actually correct, in both X (J=0-6, silent to 10 kV/cm)
+            and B with both Lambda-doublet partners retained (silent to 200 V/cm, where
+            a larger threshold produces dozens of false alarms on ordinary builds). It is
+            therefore a sufficient, not a necessary, signal: a firing warning means the
+            assignment is likely wrong, but silence is not a guarantee. Above ~10 kV/cm
+            in X, or ~500 V/cm in B with both parities, do not rely on single-shot
+            matching regardless of the margin - track adiabatically instead.
+            Set to None to disable. Defaults to 0.02.
         use_optimal_assignment (bool): If True, use Hungarian algorithm for optimal
             assignment. If False, use greedy argmax (legacy behavior, may produce
             duplicates). Defaults to True.
@@ -375,7 +394,8 @@ def find_exact_states_indices(
             assignment).
         ValueError: If greedy assignment produces duplicates (when not using optimal
             assignment).
-        UserWarning: If any overlap is below overlap_threshold.
+        UserWarning: If any assignment margin is below margin_threshold, or if any
+            overlap is below overlap_threshold when that check is enabled.
 
     Example:
         >>> # Find dressed states from bare states
@@ -389,6 +409,13 @@ def find_exact_states_indices(
     Note:
         - Overlap probability is |<approx|exact>|²
         - Hungarian algorithm minimizes total cost = Σ(1 - overlap_i)
+        - Because the assignment is optimized globally, an individual state can be
+          given its second-best eigenstate so another state can have its best; this
+          shows up as a negative margin and is a genuine ambiguity signal
+        - Matching bare states to eigenstates in a single shot fails once mixing is
+          strong (in X above roughly 20 kV/cm). Track states adiabatically instead:
+          step the field up from ~0 in small increments and match each set of
+          eigenvectors to the previous set
         - For n approximate states and m eigenstates with n ≤ m, guarantees unique assignment
         - V_ref helps maintain consistent eigenstate ordering across parameter sweeps
     """
@@ -464,17 +491,54 @@ def find_exact_states_indices(
                 f"Consider using use_optimal_assignment=True."
             )
 
-    # Warn about poor overlaps
-    poor_overlaps = max_overlaps < overlap_threshold
-    if np.any(poor_overlaps):
-        poor_indices = np.where(poor_overlaps)[0]
-        warnings.warn(
-            f"Low overlap detected for approximate states at indices {poor_indices.tolist()}. "
-            f"Overlaps: {max_overlaps[poor_overlaps].tolist()}. "
-            f"The approximate states may not be well-represented in the eigenstate basis.",
-            UserWarning,
-            stacklevel=2,
-        )
+    # Warn about ambiguous assignments: the assigned eigenstate is barely preferred
+    # over the runner-up, so the labelling is not robust against small changes in the
+    # Hamiltonian. Unlike a low absolute overlap - which strong but harmless mixing
+    # produces on its own - this indicates the assignment itself may be wrong.
+    if margin_threshold is not None:
+        runner_up = overlaps.copy()
+        runner_up[np.arange(n_approx), indices] = -np.inf
+        runner_up_indices = np.argmax(runner_up, axis=1)
+        margins = max_overlaps - runner_up[np.arange(n_approx), runner_up_indices]
+
+        ambiguous = margins < margin_threshold
+        if np.any(ambiguous):
+            ambiguous_indices = np.where(ambiguous)[0]
+            details = ", ".join(
+                f"{i} (assigned {indices[i]} at {max_overlaps[i]:.3f}, "
+                f"runner-up {runner_up_indices[i]} at "
+                f"{overlaps[i, runner_up_indices[i]]:.3f})"
+                for i in ambiguous_indices[:10]
+            )
+            if ambiguous_indices.size > 10:
+                details += f", ... ({ambiguous_indices.size} states total)"
+            warnings.warn(
+                f"Ambiguous eigenstate assignment for approximate states: {details}. "
+                f"The assigned eigenstate is not clearly preferred over the next "
+                f"candidate, so the labelling can change with a small change in field "
+                f"or with numerical noise. Treat this as a warning about the assignment "
+                f"as a whole, not only about the states listed: mis-assignments come in "
+                f"groups within a mixed manifold and a state can be assigned wrongly "
+                f"while its own margin looks acceptable. Track the states adiabatically "
+                f"instead: step the field up from ~0 in small increments and match each "
+                f"set of eigenvectors to the previous set.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+    # Warn about impure state labels, if requested. Note that strong mixing lowers
+    # every overlap without making the assignment wrong, so this is off by default.
+    if overlap_threshold is not None:
+        poor_overlaps = max_overlaps < overlap_threshold
+        if np.any(poor_overlaps):
+            poor_indices = np.where(poor_overlaps)[0]
+            warnings.warn(
+                f"Low overlap detected for approximate states at indices {poor_indices.tolist()}. "
+                f"Overlaps: {max_overlaps[poor_overlaps].tolist()}. "
+                f"The approximate states may not be well-represented in the eigenstate basis.",
+                UserWarning,
+                stacklevel=2,
+            )
 
     return indices.astype(np.int_)
 
@@ -487,7 +551,8 @@ def find_exact_states(
     H: Optional[npt.NDArray[np.complex128]] = None,
     V: Optional[npt.NDArray[np.complex128]] = None,
     V_ref: Optional[npt.NDArray[np.complex128]] = None,
-    overlap_threshold: float = 0.5,
+    overlap_threshold: Optional[float] = None,
+    margin_threshold: Optional[float] = 0.02,
     use_optimal_assignment: bool = True,
 ) -> List[CoupledState]: ...
 
@@ -500,7 +565,8 @@ def find_exact_states(
     H: Optional[npt.NDArray[np.complex128]] = None,
     V: Optional[npt.NDArray[np.complex128]] = None,
     V_ref: Optional[npt.NDArray[np.complex128]] = None,
-    overlap_threshold: float = 0.5,
+    overlap_threshold: Optional[float] = None,
+    margin_threshold: Optional[float] = 0.02,
     use_optimal_assignment: bool = True,
 ) -> List[UncoupledState]: ...
 
@@ -512,7 +578,8 @@ def find_exact_states(
     H: Optional[npt.NDArray[np.complex128]] = None,
     V: Optional[npt.NDArray[np.complex128]] = None,
     V_ref: Optional[npt.NDArray[np.complex128]] = None,
-    overlap_threshold: float = 0.5,
+    overlap_threshold: Optional[float] = None,
+    margin_threshold: Optional[float] = 0.02,
     use_optimal_assignment: bool = True,
 ):
     """Find exact eigenstates corresponding to approximate states.
@@ -533,7 +600,11 @@ def find_exact_states(
             computed from H. Defaults to None.
         V_ref (npt.NDArray[np.complex128] | None): Reference eigenvectors for
             consistent ordering. Defaults to None.
-        overlap_threshold (float): Minimum overlap probability for warning. Defaults to 0.5.
+        overlap_threshold (float | None): Minimum overlap probability for the label
+            purity warning, or None to disable it. Defaults to None.
+        margin_threshold (float | None): Minimum gap between the best and second-best
+            overlap before warning about an ambiguous assignment, or None to disable.
+            Defaults to 0.02.
         use_optimal_assignment (bool): Use Hungarian algorithm for optimal assignment.
             Defaults to True.
 
@@ -564,11 +635,12 @@ def find_exact_states(
     indices = find_exact_states_indices(
         states_approx,
         QN_construct,
-        H,
-        V,
-        V_ref,
-        overlap_threshold,
-        use_optimal_assignment,
+        H=H,
+        V=V,
+        V_ref=V_ref,
+        overlap_threshold=overlap_threshold,
+        margin_threshold=margin_threshold,
+        use_optimal_assignment=use_optimal_assignment,
     )
     return [QN_basis[idx] for idx in indices]
 

--- a/centrex_tlf/states/utils.py
+++ b/centrex_tlf/states/utils.py
@@ -3,6 +3,7 @@ from typing import List, Sequence, Tuple, TypeVar
 
 import numpy as np
 import numpy.typing as npt
+from scipy.optimize import linear_sum_assignment
 from sympy.physics.quantum.cg import CG
 
 __all__ = ["CGc", "parity_X", "reorder_evecs"]
@@ -50,6 +51,15 @@ def reorder_evecs(
 ) -> Tuple[npt.NDArray[np.complex128], npt.NDArray[np.complex128]]:
     """Reshuffle eigenvectors and eigenergies based on a reference
 
+    Column k of the returned eigenvector matrix is the input eigenvector matched to
+    column k of ``V_ref``; if ``V_ref`` has fewer columns than ``V_in``, the unmatched
+    eigenvectors follow in their original order. The matching is the assignment that maximizes the total
+    overlap ``Σ_k |⟨V_in[:, i_k] | V_ref[:, k]⟩|`` (Hungarian algorithm), which
+    guarantees a one-to-one mapping. A greedy per-eigenvector argmax does not: when
+    two input eigenvectors have their largest overlap with the same reference column
+    - which happens once states mix strongly, e.g. in X at electric fields above
+    roughly 20 kV/cm - it silently produces an arbitrary ordering instead.
+
     Args:
         V_in (np.ndarray): eigenvector matrix to be reorganized
         E_in (np.ndarray): energy vector to be reorganized
@@ -61,8 +71,18 @@ def reorder_evecs(
     # take dot product between each eigenvector in V and state_vec
     overlap_vectors = np.absolute(np.matmul(np.conj(V_in.T), V_ref))
 
-    # find which state has the largest overlap:
-    index = np.argsort(np.argmax(overlap_vectors, axis=1))
+    # optimal one-to-one matching of input eigenvectors to reference eigenvectors
+    row_ind, col_ind = linear_sum_assignment(-overlap_vectors)
+
+    # index[k] is the input eigenvector assigned to reference eigenvector k
+    index = row_ind[np.argsort(col_ind)]
+
+    # with fewer reference vectors than eigenvectors only min(N, M) get assigned; keep
+    # the rest, in their original order, so the output always holds every eigenvector
+    if index.size < V_in.shape[1]:
+        remaining = np.setdiff1d(np.arange(V_in.shape[1]), index)
+        index = np.concatenate([index, remaining])
+
     # store energy and state
     E_out = E_in[index]
     V_out = V_in[:, index]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "centrex-tlf"
-version = "0.2.2"
+version = "0.2.3"
 description = ""
 authors = [
     {name = "ograsdijk", email = "o.grasdijk@gmail.com"}

--- a/tests/lindblad/test_per_level_rotating_frame.py
+++ b/tests/lindblad/test_per_level_rotating_frame.py
@@ -140,8 +140,7 @@ def test_two_level_toy_rotated_frame_matches_original(
 def test_r2_system_rotated_frame_matches_original(detuning_mhz: float) -> None:
     diagnose = _load_diagnose_step_size()
 
-    with pytest.warns(UserWarning, match="Low overlap detected"):
-        system, ts = diagnose.build_system()
+    system, ts = diagnose.build_system()
     rotated = apply_per_level_rotating_frame(system)
 
     rabi_value = diagnose.power_to_rabi_rectangular_beam(

--- a/tests/states/test_states.py
+++ b/tests/states/test_states.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pytest
 
@@ -68,6 +70,109 @@ def test_reorder_evecs():
     E_out, V_out = states.reorder_evecs(V_in, E_in, V_ref)
     assert E_out[ida] == E_in[idb]
     assert E_out[idb] == E_in[ida]
+
+
+def test_reorder_evecs_unique_assignment():
+    # eigenvector 1 and 2 both have their largest overlap with reference column 2,
+    # so a greedy per-eigenvector argmax cannot produce a valid one-to-one ordering
+    V_in = np.array(
+        [
+            [-0.4607, 0.5716, -0.6790],
+            [-0.8465, -0.5128, 0.1427],
+            [-0.2666, 0.6405, 0.7202],
+        ],
+        dtype=np.complex128,
+    )
+    E_in = np.array([1.0, 2.0, 3.0], dtype=np.complex128)
+    V_ref = np.eye(3, dtype=np.complex128)
+
+    overlaps = np.abs(np.conj(V_in.T) @ V_ref)
+    assert len(set(np.argmax(overlaps, axis=1).tolist())) < 3
+
+    E_out, V_out = states.reorder_evecs(V_in, E_in, V_ref)
+
+    # the ordering is a permutation of the input eigenvectors
+    assignment = [
+        int(np.argmax(np.abs(np.conj(V_out[:, k]) @ V_in))) for k in range(3)
+    ]
+    assert sorted(assignment) == [0, 1, 2]
+    assert np.allclose(np.sort(E_out.real), E_in.real)
+    # and it is the assignment maximizing the total overlap with the reference
+    total = sum(overlaps[assignment[k], k] for k in range(3))
+    assert total >= max(
+        sum(overlaps[perm[k], k] for k in range(3))
+        for perm in [
+            (0, 1, 2),
+            (0, 2, 1),
+            (1, 0, 2),
+            (1, 2, 0),
+            (2, 0, 1),
+            (2, 1, 0),
+        ]
+    )
+
+
+def _embedded_V(block):
+    """Identity eigenvector matrix with `block` mixing the first few basis states."""
+    n = 16
+    V = np.eye(n, dtype=np.complex128)
+    k = block.shape[0]
+    V[:k, :k] = block
+    return V
+
+
+def test_reorder_evecs_fewer_reference_vectors():
+    # with fewer reference columns than eigenvectors every eigenvector must still be
+    # returned, the matched ones first
+    rng = np.random.default_rng(0)
+    V_in = np.linalg.qr(rng.normal(size=(6, 6)))[0].astype(np.complex128)
+    E_in = np.arange(6).astype(np.complex128)
+    V_ref = np.eye(6, dtype=np.complex128)[:, :3]
+
+    E_out, V_out = states.reorder_evecs(V_in, E_in, V_ref)
+
+    assert V_out.shape == V_in.shape
+    assert sorted(E_out.real.tolist()) == sorted(E_in.real.tolist())
+
+
+def test_find_exact_states_indices_ambiguous_assignment_warns():
+    # a 50/50 mixture of two basis states: neither label prefers either eigenvector,
+    # so the assignment is a coin flip and should be flagged
+    QN = states.generate_coupled_states_ground(Js=[0, 1])
+    states_approx = [1 * s for s in QN]
+    block = np.array([[1, 1], [1, -1]], dtype=np.complex128) / np.sqrt(2)
+
+    with pytest.warns(UserWarning, match="Ambiguous eigenstate assignment"):
+        states.find_exact_states_indices(
+            states_approx, list(QN), V=_embedded_V(block)
+        )
+
+
+def test_find_exact_states_indices_strong_mixing_does_not_warn():
+    # three-way mixing leaves the first state only 48% pure - which happens from a few
+    # hundred V/cm on - but its assignment is still unambiguous, so nothing is flagged
+    QN = states.generate_coupled_states_ground(Js=[0, 1])
+    states_approx = [1 * s for s in QN]
+    block = np.array(
+        [
+            [0.692820, 0.575968, -0.433891],
+            [0.547723, -0.811687, -0.202890],
+            [0.469042, 0.097085, 0.877824],
+        ],
+        dtype=np.complex128,
+    )
+    V = _embedded_V(block)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        indices = states.find_exact_states_indices(states_approx, list(QN), V=V)
+    assert np.all(indices == np.arange(len(QN)))
+
+    # the purity check is opt-in and does flag it
+    with pytest.warns(UserWarning, match="Low overlap detected"):
+        states.find_exact_states_indices(
+            states_approx, list(QN), V=V, overlap_threshold=0.5
+        )
 
 
 def test_quantumselector_get_indices():


### PR DESCRIPTION
## Summary

`find_exact_states_indices` warned whenever a state's overlap with its bare label fell below 0.5. That measures *label purity*, not whether the assignment is correct — and ordinary Stark mixing destroys purity long before identification breaks. Every X state drops below 0.5 above ~400 V/cm, and every B state by 100 V/cm when both Λ-doublet partners are retained, while the returned assignment stays exact (checked against adiabatic continuation from zero field). The warning fired on routine builds, and one test had codified it as expected behaviour.

This replaces it with a warning on the **margin** between the best and second-best overlap, which is the condition under which a label can actually land on the wrong eigenvector. It also fixes a latent ordering bug in `reorder_evecs`.

## Changes

- `margin_threshold` (default `0.02`) on `find_exact_states_indices` / `find_exact_states`; warns with the competing eigenstate named.
- `overlap_threshold` now defaults to `None`. Pass `0.5` to restore the old purity check.
- `reorder_evecs` uses `linear_sum_assignment` instead of `argsort(argmax(...))`. The greedy version had no uniqueness guarantee — once two eigenvectors claimed the same reference column it returned a silently arbitrary ordering. Unmatched eigenvectors are appended when `V_ref` has fewer columns, preserving the old output shape.
- AGENTS.md: identification gotchas, the field-based tracking rule, and eigenvector-level J convergence.

Returned indices are unchanged; only warning behaviour and the ordering in strongly mixed cases differ.

## Why 0.02

Calibrated so the warning is silent wherever single-shot matching is actually correct, in both manifolds. Ground truth is adiabatic tracking from zero field (step-size independent: X 50 vs 20 V/cm to 50 kV/cm; B 1.0 vs 0.2 V/cm to 1 kV/cm).

X, J=0–6 (196 levels) — flagged / of-which-wrong:

```
E (V/cm)  wrong    t=0.02      t=0.05      t=0.12
   1000       0    0 /  0      0 /  0       0 /  0
   5000       0    0 /  0      2 /  0      20 /  0
  10000       0    0 /  0     16 /  0      36 /  0
  20000       8   10 /  8     22 /  8      44 /  8
  30000       8   26 /  4     40 /  6      68 /  8
  50000      66   60 / 52     82 / 64     106 / 66
```

B, J=1–4, both parities (192 levels):

```
E (V/cm)  wrong    t=0.02      t=0.05      t=0.12
    100       0    0 /  0      0 /  0      16 /  0
  171.6       0    0 /  0      2 /  0      32 /  0
    200       0    0 /  0      4 /  0      52 /  0
    500      12    4 /  0     52 /  4      92 /  6
   1000      44   34 / 10     74 / 16     128 / 36
```

A larger threshold produces false alarms on ordinary builds — `generate_reduced_B_hamiltonian` for a J′=2 F₁=3/2 F=2 target at 171.6 V/cm warns at 0.12 and is silent at 0.02.

The margin is a **sufficient, not necessary** signal: mis-assigned states reach margins of +0.11 (X, 50 kV/cm) and +0.22 (B, 500 V/cm), so no threshold separates right from wrong cleanly. Above ~10 kV/cm in X or ~500 V/cm in B with both parities, single-shot matching is wrong rather than merely uncertain — it disagrees with tracking on 66 of 196 X states at 50 kV/cm *while scoring the higher total overlap*, so its objective prefers the physically wrong answer. That rule is now documented in AGENTS.md.

## Performance

`linear_sum_assignment` is ~2× the greedy assignment step, but that step is 0.6–2% of the `eigh` every call site already performs. In situ: 6 calls per OBE build, ~0.5 ms added, build wall time unchanged within noise.

## Tests

309 passed, 1 skipped. Added coverage for duplicate-argmax ordering, the rectangular `V_ref` case, an ambiguous assignment, and a strongly-mixed-but-unambiguous one. `tests/lindblad/test_per_level_rotating_frame.py` no longer asserts the spurious purity warning — its subject is rotating-frame equivalence.
