### PR TITLE
Gate the mF=0 main-state preference on coupling strength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.2.3
+
+### Fixed
+
+- The field-mixed fallback in `select_main_states_indices_coupling` preferred an mF = 0
+  ground state unconditionally, so it could return a pair far weaker than the strongest
+  available — contradicting its own docstring. `main_coupling` divides the whole coupling
+  matrix, so that silently scales up every Rabi rate for workflows that set `Ω` directly,
+  and the weak pair can sit above `weak_main_fraction` and escape the warning. Measured on
+  the repository's own fallback test case (X J=2 F₁=5/2 F=3 to B J=1 F₁=3/2 F=1 at
+  200 V/cm), the selected pair was 20% of the strongest, a 5x inflation. The preference now
+  applies only while the mF = 0 pair stays within `mF0_preference_fraction` (default 0.5)
+  of the strongest coupling. Pass `mF0_preference_fraction=0.0` for the previous behaviour.
+  Pass 1, which handles every bare-allowed case, is unchanged.
+- The weak-`main_coupling` warning compared `|ME_main|`, evaluated for `pol_main`, against
+  the largest element of *any* polarization's coupling matrix, and derived its "has been
+  pruned" claim from that same cross-polarization threshold. It now uses the matrix built
+  with `pol_main` when one is present. Its closing sentence also claimed the requested
+  power would map to a larger Rabi rate than intended, which is wrong for the
+  `power_to_rabi_*` helpers, where the normalization cancels.
+
 ## 0.2.2
 
 Transition validity during OBE setup is now decided by the mixed-state dipole matrix

--- a/centrex_tlf/couplings/coupling_matrix.py
+++ b/centrex_tlf/couplings/coupling_matrix.py
@@ -404,6 +404,7 @@ def select_main_states_indices_coupling(
     polarization: npt.NDArray[np.complex128],
     absolute_coupling: float = 1e-6,
     normalize_pol: bool = True,
+    mF0_preference_fraction: float = 0.5,
 ) -> Tuple[int, int]:
     """Pick the main ground/excited pair, falling back to field-mixed couplings.
 
@@ -417,6 +418,10 @@ def select_main_states_indices_coupling(
     Only when no bare-allowed pair has a non-vanishing matrix element — the case that
     used to raise outright — does this fall back to the mixed-state matrix elements, and
     then it picks the *strongest* available coupling rather than a positional heuristic.
+    An mF = 0 ground state is still preferred in that fallback, but only while it stays
+    within ``mF0_preference_fraction`` of the strongest coupling available; preferring a
+    much weaker mF = 0 pair would inflate every Rabi rate in the system, since
+    ``main_coupling`` normalizes the whole coupling matrix.
 
     Args:
         ground_states (Sequence[CoupledState]): field-dressed ground states.
@@ -424,6 +429,10 @@ def select_main_states_indices_coupling(
         polarization (npt.NDArray[np.complex128]): Jones vector [Ex, Ey, Ez].
         absolute_coupling (float): matrix elements below this count as zero.
         normalize_pol (bool): normalize the polarization vector before evaluating.
+        mF0_preference_fraction (float): in the field-mixed fallback, prefer an mF = 0
+            ground state only while its coupling is at least this fraction of the
+            strongest available. Set to 0 to always prefer mF = 0, to 1 to always take
+            the strongest pair. Defaults to 0.5.
 
     Returns:
         Tuple[int, int]: indices into ``ground_states`` and ``excited_states``.
@@ -450,7 +459,8 @@ def select_main_states_indices_coupling(
         )
 
     # Pass 1: bare-allowed pairs only, in the historical scan order. Matrix elements are
-    # evaluated lazily here so the common case stays cheap.
+    # evaluated only for pairs the bare rules already permit, which is a small subset of
+    # the full ground x excited grid; every such pair is evaluated.
     allowed: List[Tuple[int, int]] = []
     allowed_mF0: List[Tuple[int, int]] = []
     for e_idx, exc in enumerate(excited_states):
@@ -490,7 +500,14 @@ def select_main_states_indices_coupling(
             if cast(CoupledBasisState, gnd.largest).mF == 0 and me > best_me_mF0:
                 best_me_mF0, best_mF0 = me, (g_idx, e_idx)
 
-    chosen = best_mF0 if best_mF0 is not None else best
+    # Prefer mF = 0 only while it is not much weaker than the best pair available:
+    # main_coupling divides the entire coupling matrix, so a weak main pair silently
+    # scales up every Rabi rate, and it can sit above weak_main_fraction and so escape
+    # the warning in generate_coupling_field.
+    if best_mF0 is not None and best_me_mF0 >= mF0_preference_fraction * best_me:
+        chosen = best_mF0
+    else:
+        chosen = best
     if chosen is None:
         raise ValueError(
             "None of the supplied ground and excited states are coupled: every "
@@ -686,7 +703,24 @@ def generate_coupling_field(
     # weakly allowed (e.g. driveable solely through field mixing) therefore inflates
     # every Rabi rate in the system without any other visible symptom.
     if couplings and weak_main_fraction > 0:
-        strongest = max(float(np.abs(c.field).max()) for c in couplings)
+        # compare against the matrix built with pol_main where possible: ME_main is
+        # evaluated for pol_main, and pruning is applied per matrix, so mixing
+        # polarizations here would compare unrelated scales
+        pol_main_norm = np.asarray(pol_main, dtype=np.complex128)
+        if normalize_pol:
+            pol_main_norm = pol_main_norm / np.linalg.norm(pol_main_norm)
+        reference = next(
+            (
+                c
+                for c in couplings
+                if np.allclose(c.polarization, pol_main_norm)
+            ),
+            None,
+        )
+        if reference is not None:
+            strongest = float(np.abs(reference.field).max())
+        else:
+            strongest = max(float(np.abs(c.field).max()) for c in couplings)
         pruned = abs(ME_main) < max(
             absolute_coupling, relative_coupling * strongest
         )
@@ -702,10 +736,13 @@ def generate_coupling_field(
                 + f"main coupling {ground_main.largest} -> {excited_main.largest} is weak: "
                 f"|main_coupling| = {abs(ME_main):.3e} is only "
                 f"{abs(ME_main) / strongest:.2e} of the strongest coupling "
-                f"({strongest:.3e}) in the matrix. main_coupling normalizes the Rabi "
-                f"rate, so the requested power will map to a much larger Rabi rate than "
-                f"intended. Pass a more strongly coupled ground_main/excited_main pair, "
-                f"or set weak_main_fraction=0 to silence this.",
+                f"({strongest:.3e}) in the matrix. main_coupling divides the whole "
+                f"coupling matrix, so a Rabi rate set directly maps to a much larger "
+                f"physical Rabi rate than intended; the power_to_rabi_* helpers are "
+                f"unaffected, since they return main_coupling * E_field and the "
+                f"normalization cancels. Pass a more strongly coupled "
+                f"ground_main/excited_main pair, or set weak_main_fraction=0 to "
+                f"silence this.",
                 stacklevel=2,
             )
 

--- a/tests/couplings/test_field_mixed_couplings.py
+++ b/tests/couplings/test_field_mixed_couplings.py
@@ -300,17 +300,31 @@ def test_automatic_main_selection_falls_back_to_field_mixed_pairs():
             pol_vecs=[POL_X.vector],
         )
 
-    # The fallback ranks by magnitude rather than by scan position, subject to the
-    # inherited preference for an mF = 0 ground state.
-    from centrex_tlf.couplings.coupling_matrix import _dress_states
+    # The fallback ranks by magnitude rather than by scan position. The inherited
+    # preference for an mF = 0 ground state only applies while that pair stays within
+    # mF0_preference_fraction of the strongest coupling; here the best mF = 0 pair is
+    # five times weaker, so the strongest pair wins.
+    from centrex_tlf.couplings.coupling_matrix import (
+        _dress_states,
+        select_main_states_indices_coupling,
+    )
 
     g = _dress_states(ground, H.QN_basis, H.QN, H.H_int, H.V_ref_int)
     e = _dress_states(excited, H.QN_basis, H.QN, H.H_int, H.V_ref_int)
-    best_mF0 = max(
-        abs(hamiltonian.generate_ED_ME_mixed_state(ex, gd, pol_vec=POL_X.vector))
-        for ex in e
-        for gd in g
-        if gd.largest.mF == 0
+
+    def me(gd, ex):
+        return abs(hamiltonian.generate_ED_ME_mixed_state(ex, gd, pol_vec=POL_X.vector))
+
+    best = max(me(gd, ex) for ex in e for gd in g)
+    best_mF0 = max(me(gd, ex) for ex in e for gd in g if gd.largest.mF == 0)
+    assert best_mF0 < 0.5 * best
+
+    np.testing.assert_allclose(abs(field.main_coupling), best, rtol=1e-6)
+
+    # the preference is a knob, not a rule: disabling the strength gate restores the
+    # historical mF = 0 choice
+    g_idx, e_idx = select_main_states_indices_coupling(
+        g, e, POL_X.vector, mF0_preference_fraction=0.0
     )
-    np.testing.assert_allclose(abs(field.main_coupling), best_mF0, rtol=1e-6)
-    assert field.ground_main.largest.mF == 0
+    assert g[g_idx].largest.mF == 0
+    np.testing.assert_allclose(me(g[g_idx], e[e_idx]), best_mF0, rtol=1e-6)


### PR DESCRIPTION
## Summary

Follow-up to the review of `cbe8290`. One real defect plus two accuracy fixes in the same area. Independent of #23 (state identification) — both target 0.2.3.

## The defect

`select_main_states_indices_coupling`'s field-mixed fallback ended with

```python
chosen = best_mF0 if best_mF0 is not None else best
```

so an mF=0 ground state was preferred **regardless of how weak it was**, contradicting the function's own docstring: *"it picks the strongest available coupling rather than a positional heuristic."*

That matters because `main_coupling` divides the entire coupling matrix in `generate_hamiltonian.py`. A weak main pair silently scales up every Rabi rate in any workflow that sets `Ω` directly (the `power_to_rabi_*` helpers are immune — `Ω = main_coupling · E` cancels the normalization). And the weak pair can sit *above* `weak_main_fraction = 1e-2`, so the warning added in `cbe8290` does not fire.

The repository's own fallback test had pinned the old behaviour and failed against the fix, which is the cleanest possible confirmation:

```
ACTUAL:  0.15854   (strongest available)
DESIRED: 0.031989  (best mF=0 pair, what the old code chose)
```

A 5× inflation of every Rabi rate, silent. Forcing the fallback on a second manifold (same-parity pairing at 200 V/cm) gives the same picture: the mF=0 pair is 48% of the strongest under X̂ and **13%** under Ẑ.

## Changes

- `mF0_preference_fraction` (default `0.5`, last parameter so positional calls are unaffected): prefer mF=0 only while it stays within that fraction of the strongest coupling. `0.0` restores the previous behaviour, `1.0` always takes the strongest. **Pass 1 — every bare-allowed case, i.e. essentially all existing builds — is untouched**, so selected pairs and `main_coupling` values are unchanged outside the fallback.
- The weak-`main_coupling` warning compared `|ME_main|` (evaluated for `pol_main`) against the largest element of *any* `pol_vecs` matrix, and derived its "has been pruned" claim from that cross-polarization threshold. It now uses the matrix built with `pol_main` when present. Measured impact was small (max|coupling| 2.61e-01 for X̂ vs 3.94e-01 for Ẑ, ratio 1.5, against a 100× trigger), so this is correctness of the comparison rather than a live bug.
- The warning's closing sentence claimed the requested power maps to a larger Rabi rate than intended — false for the `power_to_rabi_*` path. Reworded to name the case that actually inflates.
- Corrected the "evaluated lazily" comment in pass 1: it evaluates a matrix element for every bare-allowed pair.

## Tests

305 passed, 1 skipped. `test_automatic_main_selection_falls_back_to_field_mixed_pairs` now asserts the strongest pair is chosen, that the best mF=0 pair really is more than 2× weaker in that scenario, and that `mF0_preference_fraction=0.0` restores the historical choice.

## Note

`CHANGELOG.md` will conflict with #23 — both add a `## 0.2.3` section. Merge the two bullet lists into one section; the version bump to 0.2.3 lives in #23.

## Reviewed and dismissed

Three further findings from the same review did not survive checking:

- **`coupling_matrix.py:640`** — that dressing a main state alone can disagree with the manifold-wide dressing. Compared both for all 20 X J=2 states at 0/50/200/1000/5000/20000 V/cm: 0 differences.
- **`utils_setup.py:407`** — that `cbe8290`'s "fixes it rejecting selectors with no explicit main states" is untrue. The claim is about OBE setup, which no longer calls the diagnostic; a selector with `ground_mains` set and `excited_mains=None` builds fine (29 levels). The deprecated function still raises when called directly, consistently with the commit.
- **`coupling_matrix.py:452` perf** — `select_main_states_indices_coupling` costs 4.2 ms on a 20×3 manifold against a ~1.5 s build.
