### PR TITLE
Warn that adiabatic tracking has its own failure mode, and add eigenstate_quantum_numbers

### DIFF
--- a/centrex_tlf/states/find_states.py
+++ b/centrex_tlf/states/find_states.py
@@ -416,6 +416,18 @@ def find_exact_states_indices(
           strong (in X above roughly 20 kV/cm). Track states adiabatically instead:
           step the field up from ~0 in small increments and match each set of
           eigenvectors to the previous set
+        - Adiabatic tracking has its own, separate failure mode, and it is not the
+          one this margin detects. Where two levels cross, the population follows
+          its diabatic branch while the overlap matching follows the adiabatic one,
+          so the label ends up on the wrong state. In TlF this is not exotic: mF=0
+          levels cross exactly when B is perpendicular to E, and a small B parallel
+          to E opens a gap of only about 1620 Hz/G, which is traversed
+          diabatically. Note the direction -- a *finer* step makes the adiabatic
+          label MORE likely to be wrong, not less, because it resolves a crossing
+          that a coarse step jumps over, and each step's assignment is unambiguous
+          throughout so no margin fires. Where the answer matters, identify states
+          by their quantum numbers at the field of interest rather than by any
+          carried index
         - For n approximate states and m eigenstates with n ≤ m, guarantees unique assignment
         - V_ref helps maintain consistent eigenstate ordering across parameter sweeps
     """

--- a/centrex_tlf/states/utils.py
+++ b/centrex_tlf/states/utils.py
@@ -6,7 +6,7 @@ import numpy.typing as npt
 from scipy.optimize import linear_sum_assignment
 from sympy.physics.quantum.cg import CG
 
-__all__ = ["CGc", "parity_X", "reorder_evecs"]
+__all__ = ["CGc", "parity_X", "reorder_evecs", "eigenstate_quantum_numbers"]
 
 
 @lru_cache(maxsize=int(1e6))
@@ -124,3 +124,82 @@ def get_unique_list(states: Sequence[DType]) -> List[DType]:
         return np.asarray(states_unique)
     else:
         return states_unique
+
+
+def _coupled_transform(QN: Sequence) -> Tuple[npt.NDArray, npt.NDArray, npt.NDArray]:
+    """Return ``U[c, u] = <coupled c|uncoupled u>``, and F and F1 per coupled index."""
+    decompositions = [q.transform_to_coupled() for q in QN]
+    keys: dict = {}
+    for decomposition in decompositions:
+        for _, coupled in decomposition.data:
+            key = (coupled.electronic_state, coupled.J, coupled.F1, coupled.F, coupled.mF)
+            keys.setdefault(key, len(keys))
+
+    U = np.zeros((len(keys), len(QN)), dtype=complex)
+    for u, decomposition in enumerate(decompositions):
+        for amplitude, coupled in decomposition.data:
+            key = (coupled.electronic_state, coupled.J, coupled.F1, coupled.F, coupled.mF)
+            U[keys[key], u] += amplitude
+
+    ordered = sorted(keys, key=keys.get)
+    F_of_coupled = np.array([key[3] for key in ordered], dtype=float)
+    F1_of_coupled = np.array([key[2] for key in ordered], dtype=float)
+    return U, F_of_coupled, F1_of_coupled
+
+
+def _spread(weights: npt.NDArray, values: npt.NDArray) -> npt.NDArray:
+    mean = weights.T @ values
+    return np.sqrt(np.maximum(weights.T @ values**2 - mean**2, 0.0))
+
+
+def eigenstate_quantum_numbers(V: npt.NDArray, QN: Sequence) -> dict:
+    """(J, F1, F, mF) expectation values and spreads for each column of ``V``.
+
+    Identifies eigenstates by what they are rather than by where they sit in an
+    array. That matters wherever an index has been carried across a parameter
+    sweep or a trajectory: `reorder_evecs` labels adiabatically, and at a level
+    crossing the population follows its diabatic branch while the label follows
+    the other, silently. Selecting on quantum numbers is immune to this.
+
+    Every returned array has one entry per eigenvector, and each quantum number
+    is accompanied by a ``*_spread``. A spread near zero means the quantum number
+    is good for that state and the label is meaningful; a large spread means the
+    state is a mixture and it is not. Check the spread rather than assuming: in a
+    strong Stark field F is badly mixed and only becomes good near zero field,
+    while mF = mJ + m1 + m2 is exact in the uncoupled basis throughout.
+
+    Note that ``(J, F, mF)`` is not a complete label -- J=1 has two F=1 levels,
+    one from F1=1/2 and one from F1=3/2 -- so F1 is returned as well.
+
+    Args:
+        V: eigenvector matrix, columns are eigenvectors, in the ``QN`` basis
+        QN: the basis states ``V`` is expressed in
+
+    Returns:
+        dict of arrays: ``J``, ``F1``, ``F``, ``mF`` and a ``*_spread`` for each
+    """
+    V = np.asarray(V, dtype=complex)
+    if V.ndim == 1:
+        V = V[:, np.newaxis]
+
+    weights = np.abs(V) ** 2
+    weights = weights / weights.sum(axis=0, keepdims=True)
+
+    mF_uncoupled = np.array([q.mJ + q.m1 + q.m2 for q in QN], dtype=float)
+    J_uncoupled = np.array([q.J for q in QN], dtype=float)
+
+    U, F_of_coupled, F1_of_coupled = _coupled_transform(QN)
+    coupled_weights = np.abs(U @ V) ** 2
+    coupled_weights = coupled_weights / coupled_weights.sum(axis=0, keepdims=True)
+    mean_FF1 = coupled_weights.T @ (F_of_coupled * (F_of_coupled + 1))
+
+    return {
+        "J": weights.T @ J_uncoupled,
+        "J_spread": _spread(weights, J_uncoupled),
+        "F1": coupled_weights.T @ F1_of_coupled,
+        "F1_spread": _spread(coupled_weights, F1_of_coupled),
+        "F": (-1 + np.sqrt(1 + 4 * mean_FF1)) / 2,
+        "F_spread": _spread(coupled_weights, F_of_coupled),
+        "mF": weights.T @ mF_uncoupled,
+        "mF_spread": _spread(weights, mF_uncoupled),
+    }


### PR DESCRIPTION
`find_states.py` recommends adiabatic tracking as the robust remedy when
single-shot matching fails under strong mixing. That advice is sound as far as it
goes, but it has a counterexample worth naming, found while debugging a
downstream simulation that read exactly `1.000000` where it should have read
`~0.90`.

## The failure mode

Where two levels cross, the population follows its **diabatic** branch while the
overlap matching follows the **adiabatic** one, so the label lands on the wrong
state.

In TlF this is not exotic: `mF=0` levels cross exactly when `B` is perpendicular
to `E`, and a small `B` parallel to `E` opens a gap of only about 1620 Hz/G.

Two things make it nasty:

- **The direction is counter-intuitive.** A *finer* step makes the adiabatic
  label MORE likely to be wrong, not less, because it resolves a crossing that a
  coarse step jumps over. Measured downstream: the state's population held
  0.99999 at every `N_steps` from 2000 to 160000, while its *index* moved at
  160000 alone.
- **`margin_threshold` cannot catch it.** Each individual step's assignment is
  unambiguous (overlap ~ 1) and still wrong, so no margin ever fires. The guard
  is silent exactly where the answer is bad.

## Changes

- **`find_states.py`** — documents the caveat alongside the existing advice,
  and points at identifying states by quantum numbers where the answer matters.
- **`utils.py`** — adds `eigenstate_quantum_numbers(V, QN)`, the alternative the
  caveat points at: `(J, F1, F, mF)` expectation values per eigenvector, built
  entirely from `UncoupledBasisState.transform_to_coupled()`.

Each quantum number comes with a `*_spread`, so a caller can distinguish a
meaningful label from a mixture rather than assuming — `F` is badly mixed in a
strong Stark field, while `mF = mJ + m1 + m2` stays exact throughout. `F1` is
returned because `(J, F, mF)` is not a complete label: J=1 has two F=1 levels,
one from F1=1/2 and one from F1=3/2.

Docs and one new pure function; no existing behaviour changes.

## Testing

`410 passed, 5 skipped in 93.07s` — unchanged from before.
